### PR TITLE
Fix remote code execution #1

### DIFF
--- a/webhelpdesk/getfield.php
+++ b/webhelpdesk/getfield.php
@@ -1,6 +1,6 @@
 <?php
 
-	$output=shell_exec('/usr/local/bin/whdapi.sh ' . $_GET['field'] . ' ' . 'mac-address' . ' ' . $_GET['mac_address']);
+	$output=shell_exec('/usr/local/bin/whdapi.sh ' . escapeshellarg($_GET['field']) . ' ' . 'mac-address' . ' ' . escapeshellarg($_GET['mac_address']));
 	echo $output;
 #}
 


### PR DESCRIPTION
Fix remote code execution vulnerability caused by passing unsanitized user inputs to a shell.
